### PR TITLE
Adds two basic parameters: batch size and operating mode

### DIFF
--- a/mais/command_line.py
+++ b/mais/command_line.py
@@ -3,9 +3,22 @@ from __future__ import absolute_import
 import click
 
 @click.command()
-@click.option('--batch', '-b', default=1, help='How many seasons should be simulated in a batch?')
 @click.argument('mode', type=click.Choice(['single','each']), default='single')
+@click.argument('competition', type=click.Choice(['mls']), default='mls')
+@click.option('--model', '-m', type=click.Choice(['v1','v2']), default='v2', help='Which prediction model should be used?')
+@click.option('--batch', '-b', default=5, help='How many seasons should be simulated in a batch?')
 
-def main(batch, mode):
-	click.echo('Operating in \'' + mode + '\' mode')
-	click.echo('Batch size: ' + str(batch))
+def main(batch, mode, competition, model):
+	# Reflect back the configuration being used
+	click.echo('Competition: ' + competition)
+	click.echo('Mode:        ' + mode)
+	click.echo('Batch size:  ' + str(batch))
+	click.echo('Using model: ' + model)
+
+	# Initialize
+
+	# Run simulations
+
+	# Output data
+
+	# Visualize?

--- a/mais/command_line.py
+++ b/mais/command_line.py
@@ -1,5 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import click
 
-def main():
-	print('Hello, world!')
+@click.command()
+@click.option('--batch', '-b', default=1, help='How many seasons should be simulated in a batch?')
+@click.argument('mode', type=click.Choice(['single','each']), default='single')
+
+def main(batch, mode):
+	click.echo('Operating in \'' + mode + '\' mode')
+	click.echo('Batch size: ' + str(batch))

--- a/mais/command_line.py
+++ b/mais/command_line.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+from datetime import date
 import click
 
 @click.command()
@@ -7,10 +8,12 @@ import click
 @click.argument('competition', type=click.Choice(['mls']), default='mls')
 @click.option('--model', '-m', type=click.Choice(['v1','v2']), default='v2', help='Which prediction model should be used?')
 @click.option('--batch', '-b', default=5, help='How many seasons should be simulated in a batch?')
+@click.option('--season', '-s', type=click.IntRange(2011,date.today().year), default=date.today().year, help='What season should be simulated? (2011-present)')
 
-def main(batch, mode, competition, model):
+def main(mode, competition, model, batch, season):
 	# Reflect back the configuration being used
 	click.echo('Competition: ' + competition)
+	click.echo('Season:      ' + str(season))
 	click.echo('Mode:        ' + mode)
 	click.echo('Batch size:  ' + str(batch))
 	click.echo('Using model: ' + model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Click==7.0
--e git+git@github.com:matt-bernhardt/mais.git@34f6dace092d54931e4dcecdbd6929e52c72e32f#egg=mais
+-e git+git@github.com:matt-bernhardt/mais.git@bd28fc859558b6ebaa266095cf3124f0a95e53ac#egg=mais
 mysql-connector-python-rf==2.2.2
 xlrd==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Click==7.0
+-e git+git@github.com:matt-bernhardt/mais.git@34f6dace092d54931e4dcecdbd6929e52c72e32f#egg=mais
 mysql-connector-python-rf==2.2.2
 xlrd==1.1.0


### PR DESCRIPTION
This integrates the Click tool to orchestrate the implementation of command line parameters. At least initially, some values anticipated are:

- [x] A fixed-choice list of operating mode, one for running a batch of simulations from a specific date, and the other for running a sequence of simulations for each day on which matches have occurred.
- [x] An option to override the batch size governing how many simulations are run each time (would default to 10,000)
- [x] An option to specify what year should be the subject of our inquiry.
- [x] (possibly) an option to specify what competition is being simulated.
- [x] An argument to swap between various models to use. The simplest would only look at which was the home team, while more nuanced implementations could consider factors like days of rest, general fatigue/fixture congestion, average lineup rotation, or points per game along various thresholds.