### PR TITLE
Adds model-switching

### DIFF
--- a/mais/command_line.py
+++ b/mais/command_line.py
@@ -38,7 +38,7 @@ def check_db(ctx, param, value):
 @click.option('--check-db', is_flag=True, callback=check_db, is_eager=True,
               expose_value=False, help='Check database connection')
 @click.option('--model', '-m', type=click.Choice(['v0', 'v1', 'v2']),
-              default='v0', help='Which prediction model should be used?')
+              default='v1', help='Which prediction model should be used?')
 @click.option('--batch', '-b', default=10000,
               help='How many seasons should be simulated in a batch?')
 @click.option('--season', type=click.IntRange(1996, date.today().year),

--- a/mais/game.py
+++ b/mais/game.py
@@ -12,13 +12,17 @@ class Game(Record):
 
     def calculateThreshold(self, model):
         """
-        This will eventually calculate different values for the home and draw
-        thresholds based on parameters passed to it. For now, it just uses a
-        1/3 1/3 1/3 distribution.
+        This implements a pythonic switch statement to return the relevant
+        result thresholds.
+        Source: Jaxenter.com 's article "How to implement a switch-case
+        statement in Python'"
         """
-        threshold = {}
-        threshold['home'] = 0.3333
-        threshold['draw'] = 0.6667
+        switcher = {
+            'v0': self.modelV0,
+            'v1': self.modelV1
+        }
+        function = switcher.get(model, lambda: modelV1)
+        threshold = function()
         return threshold
 
     def lookupGamesBySeason(self, season, competition, start, log):
@@ -55,6 +59,30 @@ class Game(Record):
         log.message('Found ' + str(self.game_count) + ' games')
 
         return self
+
+    def modelV0(self):
+        """
+        This is an extremely naive model which sets each game result as
+        equally likely: a 1/3 1/3 1/3 distribution.
+        """
+        threshold = {}
+        threshold['home'] = 0.3333
+        threshold['draw'] = 0.6667
+        return threshold
+
+    def modelV1(self):
+        """
+        The v1 model is the first one that I started using, which is based on
+        actual home field advantage in MLS - across all teams and from 2011 -
+        2017.
+        """
+        home = 972.0
+        draw = 533.0
+        away = 450.0
+        threshold = {}
+        threshold['home'] = home / (home + draw + away)
+        threshold['draw'] = (home + draw) / (home + draw + away)
+        return threshold
 
     def simulateResult(self, context, model):
         """

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with io.open('LICENSE') as f:
 
 setup(
     name='mais',
-    version='0.2.0',
+    version='0.3.0',
     description='Predict games in Major League Soccer',
     url='https://github.com/matt-bernhardt/mais',
     license=license,
@@ -32,7 +32,7 @@ setup(
         'console_scripts': ['mais=mais.command_line:main'],
     },
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intendend Audience :: Other Audience',
         'Environment :: Console',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -23,6 +23,19 @@ def test_game_connection():
     assert hasattr(g, 'db') is False
 
 
+def test_game_calculateThreshold():
+    log = Log('test.log')
+    model = 'v0'
+    g = Game()
+    # This tests the ability to get back different models based on a passed
+    # parameter.
+    threshold = g.calculateThreshold(model)
+    assert threshold['home'] == 0.3333
+    model = 'v1'
+    threshold = g.calculateThreshold(model)
+    assert threshold['home'] == 972.0 / 1955.0
+
+
 def test_game_lookupGamesBySeason():
     log = Log('test.log')
     g = Game()
@@ -33,6 +46,25 @@ def test_game_lookupGamesBySeason():
     assert len(g.games) == 0
     g.lookupGamesBySeason(1996, 'mls', '1996-01-01', log)
     assert len(g.games) == 160
+
+
+def test_game_modelV0():
+    log = Log('test.log')
+    model = 'v0'
+    g = Game()
+    threshold = g.modelV0()
+    assert threshold['home'] == 0.3333
+    assert threshold['draw'] == 0.6667
+
+
+def test_game_modelV1():
+    log = Log('test.log')
+    model = 'v1'
+    g = Game()
+    threshold = g.modelV1()
+    assert threshold['home'] == 972.0 / 1955.0
+    assert threshold['draw'] == 1505.0 / 1955.0
+
 
 def test_game_simulateResult():
     log = Log('test.log')


### PR DESCRIPTION
This adds the `v1` model to the code, in addition to the previously-used `v0` model. It also sets the v1 model as the default, and implements switching logic to choose which one gets used based on a command line option.

The v0 model is something I would avoid using for anything reasonable - it assigns each outcome (home win, draw, and away win) as equally likely, which flies in the face of logic and actual observations.

The v1 model is only slightly better - it assigns likelihood of result based on observed home field advantage in MLS for all teams - but it is at least not hopelessly naive.